### PR TITLE
Add Docker-based deployment with bundled Postgres

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.git
+.gitignore
+.env
+.env.*
+uploads
+backups
+test-results
+logs
+coverage
+.idea
+.vscode
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Application configuration
+NODE_ENV=production
+PORT=3010
+
+# Primary database connection used by the application
+DB_HOST=db
+DB_PORT=5432
+DB_NAME=vulnerability_reports
+DB_USER=report_gen
+DB_PASSWORD=StarDust
+# Set to true to enable SSL connections when using a managed database service
+DB_SSL=false
+# Optional: control whether SSL certificates should be verified when DB_SSL=true
+DB_SSL_REJECT_UNAUTHORIZED=true
+
+# Connection pool tuning (optional)
+DB_POOL_MAX=20
+DB_POOL_IDLE_TIMEOUT=30000
+DB_POOL_CONNECTION_TIMEOUT=2000
+
+# Postgres container bootstrap credentials.
+# These values should match the DB_* settings above when using docker-compose.
+POSTGRES_DB=vulnerability_reports
+POSTGRES_USER=report_gen
+POSTGRES_PASSWORD=StarDust

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-bullseye
+
+WORKDIR /usr/src/app
+
+# Install system dependencies required by the application
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production \
+    PORT=3010
+
+EXPOSE 3010
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -20,24 +20,80 @@ A comprehensive web application for uploading, processing, and analyzing AWS Ins
   - Notion-compatible markdown text
 - **Data Management**: PostgreSQL database with connection pooling for reliable persistence
 
-## Installation
+## Prerequisites
 
-1. Navigate to the project directory:
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2 for the containerized stack
+- Node.js 18+ (optional, only required for running the app directly on your machine)
+- npm (ships with Node.js)
+
+## Quick start (Docker)
+
+1. Copy the example environment file and adjust it to your needs:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Start the full stack (application + PostgreSQL) using Docker Compose:
+   ```bash
+   docker compose up --build
+   ```
+
+   The first startup will take a little longer because the PostgreSQL container applies the schema from `migrations/postgresql/000-initial-seed.sql`.
+
+3. Open your browser to http://localhost:3010 and begin uploading AWS Inspector reports.
+
+4. To stop the stack, press <kbd>Ctrl</kbd> + <kbd>C</kbd> and then optionally remove containers with:
+   ```bash
+   docker compose down
+   ```
+
+Persistent application uploads/backups and the PostgreSQL data directory are stored in Docker volumes so that data survives restarts.
+
+## Configuration
+
+The application reads its configuration from environment variables. The `.env.example` file documents all supported options and sensible defaults for the bundled PostgreSQL instance. Common settings include:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `DB_HOST` | Database hostname | `db` (Docker) / `localhost` (manual) |
+| `DB_PORT` | Database port | `5432` |
+| `DB_NAME` | Database name | `vulnerability_reports` |
+| `DB_USER` | Database user | `report_gen` |
+| `DB_PASSWORD` | Database password | `StarDust` |
+| `DB_SSL` | Enable SSL when connecting to a managed PostgreSQL service | `false` |
+| `DB_POOL_MAX` | Maximum number of pooled connections | `20` |
+
+To connect to an external database (for example in production), set the `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and `DB_SSL` values in your `.env` file accordingly. When these variables are omitted the application automatically connects to the co-located PostgreSQL container.
+
+The same `.env` file is shared by Docker Compose and the Node.js application so you only have to define credentials once.
+
+## Deploying to the cloud
+
+Build and push the Docker image to your preferred registry:
+
 ```bash
-cd vulnerability-dashboard
+docker build -t <your-registry>/aws-inspector-report-tool:latest .
+docker push <your-registry>/aws-inspector-report-tool:latest
 ```
 
-2. Install dependencies:
-```bash
-npm install
-```
+Provision a managed PostgreSQL instance (or reuse an existing one) and configure the required environment variables on your hosting platform (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and optionally `DB_SSL`). When the container starts without those variables it will fall back to the bundled database configuration, making it easy to run the application in single-node environments as well.
 
-3. Start the server:
-```bash
-npm start
-```
+## Running locally without Docker
 
-4. Open your browser to: http://localhost:3010
+If you prefer running the Node.js app directly on your workstation:
+
+1. Ensure PostgreSQL is running and accessible. Create the database, user, and run the schema from `migrations/postgresql/000-initial-seed.sql`.
+2. Copy and adjust the environment file:
+   ```bash
+   cp .env.example .env
+   ```
+3. Update the database variables in `.env` to point to your local PostgreSQL instance (for example, set `DB_HOST=localhost`).
+4. Install dependencies and start the development server:
+   ```bash
+   npm install
+   npm start
+   ```
+5. Visit http://localhost:3010 in your browser.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    container_name: inspector-db
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-vulnerability_reports}
+      POSTGRES_USER: ${POSTGRES_USER:-report_gen}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-StarDust}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./migrations/postgresql:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-report_gen} -d ${POSTGRES_DB:-vulnerability_reports}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build: .
+    container_name: inspector-app
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${PORT:-3010}
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_NAME: ${DB_NAME:-vulnerability_reports}
+      DB_USER: ${DB_USER:-report_gen}
+      DB_PASSWORD: ${DB_PASSWORD:-StarDust}
+    ports:
+      - "3010:3010"
+    volumes:
+      - uploads-data:/usr/src/app/uploads
+      - backups-data:/usr/src/app/backups
+
+volumes:
+  postgres-data:
+  uploads-data:
+  backups-data:

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const HistoryService = require('./src/services/historyService');
 const SettingsService = require('./src/services/settingsService');
 
 const app = express();
-const PORT = 3010;
+const PORT = process.env.PORT || 3010;
 
 // Middleware
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose.yml to run the app with a bundled PostgreSQL database
- provide an example environment file and Docker ignore rules for container builds
- make configuration env-driven (including PORT) and update documentation for containerized/cloud deployment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2ba63000832680c26d408420dc99